### PR TITLE
feature: :seedling: create Dockerfile for jenkins

### DIFF
--- a/jenkins/Dockerfile
+++ b/jenkins/Dockerfile
@@ -1,0 +1,9 @@
+LABEL AUTHOR="tae2089"
+
+# jenkins에 awscli를 설치한 파일입니다.
+FROM jenkins/jenkins
+USER root
+
+RUN apt-get update && apt install python3-pip jq -y && pip3 install awscli --upgrade && groupadd -g 992 docker && usermod -aG 992 jenkins
+
+USER jenkins


### PR DESCRIPTION
CICD에 많이 쓰이는 Jenkins에 awscli를 설치한 도커 파일입니다.

이 파일을 활용하면 aws에 s3 업로드 자동화, ECR 컨테이너 이미지 업로드 등이 가능합니다.